### PR TITLE
0515_리퀘스트입니다

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -408,5 +408,12 @@ textarea {
 .pagingWrap {
 	display: flex;
 	justify-content: center;
-	margin: 2rem;
+	margin: 1rem 0 1rem 0;
+}
+.movePage {
+	width: 100%;
+}
+.movePage form {
+	width: 200px;
+	margin: 1rem auto;
 }

--- a/public/js/movePage.js
+++ b/public/js/movePage.js
@@ -1,0 +1,7 @@
+function movePages() {
+    const getPage = document.getElementById('inputPage').value;
+    let addr = '/pages/community?page='
+    console.log(addr.concat(getPage));
+    
+    window.location.href = addr.concat(getPage);
+}

--- a/public/js/movePage.js
+++ b/public/js/movePage.js
@@ -1,7 +1,11 @@
 function movePages() {
     const getPage = document.getElementById('inputPage').value;
+    const maxPage = document.getElementById('maxPage').value;
     let addr = '/pages/community?page='
-    console.log(addr.concat(getPage));
-    
-    window.location.href = addr.concat(getPage);
+
+    console.log(getPage + " / " + maxPage);
+    if(getPage > maxPage || getPage < 1)
+        alert("번호를 재확인하세요");
+    else
+        window.location.href = addr.concat(getPage);
 }

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -952,14 +952,11 @@ router.get('/community', async (req, res, next) => {
     try {
         // 페이징 준비
         console.log("page = ", req.query.page);
-        let pageNum = req.query.page; // 전체 게시물 수
+        let pageNum = req.query.page;
         let offset = 0;
-        if(pageNum > 1){  // 보여줄 게시물 수
+        if(pageNum > 1){
             offset = 3 * (pageNum - 1);
         }
-        // 페이징 추가
-        let maxPage;
-
         const [communities] = await Promise.all([
             Community.findAll({
                 order: [['createdAt', 'ASC']],

--- a/views/community.html
+++ b/views/community.html
@@ -58,8 +58,9 @@
                         <!-- 이전 페이지 = 현재페이지 - 1 -->
                         <a class="page-link" href="/pages/community?page={{currentPage - 1}}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
                     </li>
-                    {% for i in maxPage%} <!-- for문으로 페이지 번호 추가-->
-                    <li class="page-item"><a class="page-link" href="/pages/community?page=i">{{i}}</a></li>
+                    {% set cnt += 1 %}
+                    {% for i in communities %} <!-- for문으로 페이지 번호 추가-->
+                    <li class="page-item"><a class="page-link" href="/pages/community?page={{cnt}}">{{cnt}}</a></li>
                     <!-- <li class="page-item"><a class="page-link" href="/pages/community?page=2">2</a></li>
                     <li class="page-item"><a class="page-link" href="/pages/community?page=3">3</a></li> -->
                     {% endfor %}

--- a/views/community.html
+++ b/views/community.html
@@ -52,20 +52,21 @@
             </div>
 
             <!-- 페이징 -->
+            {% set pageBlock = 2 %}
             <div class="pagingWrap">
                 <ul id="Postpages"class="pagination">
-                    <li class="page-item">
-                        <!-- 이전 페이지 = 현재페이지 - 1 -->
+                    <li class="page-item {% if currentPage <= 1%}disabled{% endif %}">
                         <a class="page-link" href="/pages/community?page={{currentPage - 1}}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
                     </li>
                     {% for i in maxPage%} <!-- for문으로 페이지 번호 추가-->
+                        {% if i==0 or i+1==maxPage|length or (i+1>=currentPage-pageBlock and i+1<=currentPage|int+pageBlock) %}
                         <li class="page-item"><a class="page-link" href="/pages/community?page={{ i + 1 }}">{{ i + 1 }}</a></li>
-                        <!-- <li class="page-item"><a class="page-link" href="/pages/community?page=2">2</a></li>
-                        <li class="page-item"><a class="page-link" href="/pages/community?page=3">3</a></li> -->
+                        {% elif i==1 or i+1==maxPage|length-2%}
+                        <li class="page-item"><a class="page-link">..</a></li>
+                        {% endif %}
                     {% endfor %}
-                    <li class="page-item">
-                        <!-- 다음 페이지 = 현재페이지 + 1 -->
-                      <a class="page-link" href="/pages/community?page={{currentPage + 1}}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+                    <li class="page-item {% if currentPage >= maxPage | length %}disabled{% endif %}">
+                        <a class="page-link" href="/pages/community?page={{ currentPage | int + 1 }}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
                     </li>
                   </ul>
             </div>

--- a/views/community.html
+++ b/views/community.html
@@ -66,7 +66,13 @@
                     <li class="page-item {% if currentPage >= maxPage | length %}disabled{% endif %}">
                         <a class="page-link" href="/pages/community?page={{ currentPage | int + 1 }}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
                     </li>
-                  </ul>
+                </ul>
+            </div>
+            <div class="movePage">
+                <form action="javascript:movePages()" class="d-flex">
+                    <input class="form-control" id="inputPage" type="number" placeholder="move page">
+                    <input type="submit" class="btn-primary border-0">
+                </form>
             </div>
         </main>
 
@@ -83,6 +89,7 @@
     <script src="/js/topNav.js"></script>
     <script src="/js/bootstrap.bundle.min.js"></script>
     <script src="/js/paging.js"></script>
+    <script src="/js/movePage.js"></script>
 </body>
 
 </html>

--- a/views/community.html
+++ b/views/community.html
@@ -71,6 +71,7 @@
             <div class="movePage">
                 <form action="javascript:movePages()" class="d-flex">
                     <input class="form-control" id="inputPage" type="number" placeholder="move page">
+                    <input id="maxPage" type="number" value="{{maxPage|length}}" hidden>
                     <input type="submit" class="btn-primary border-0">
                 </form>
             </div>

--- a/views/community.html
+++ b/views/community.html
@@ -36,7 +36,6 @@
                 <!-- 각 게시물 -->
                 {% for community in communities %}
                 <div id="postNum_{{loop.index}}" class="postingList border p-5" onclick="location.href='/free_community/community/{{community.id}}'">
-                    <a>{{loop.index}}</a>
                     <div class="pb-3 border-bottom">
                         <h1 class="h5 fw-bold text-primary">{{community.category}}</h1>
                         <div class="d-sm-flex justify-content-between align-items-center mb-3">
@@ -48,7 +47,6 @@
                     <p class="postingBody pt-3">{{community.content}}</p>
                 </div>
                 {% endfor %}
-                <!-- <div style='page-break-before:always'></div> -->
             </div>
 
             <!-- 페이징 -->


### PR DESCRIPTION
페이징 현재페이지가 첫 페이지거나 마지막 페이지일 경우 이동 버튼(<</>>)을 비활성화 합니다
다음 페이지 이동(currentPage + 1)이 글자로 취급되는 현상이 있었습니다 currentPage를 int로 형변환 하여 해결하였습니다
중간 페이지 일 때 현재 페이지 +-2만큼의 페이지를 표시하고 나머지는 생략합니다